### PR TITLE
Fix Numpy deprecation: replace `numpy.fromstring` with `numpy.frombuffer` in audio_file_reader.py

### DIFF
--- a/src/dr14meter/audio_file_reader.py
+++ b/src/dr14meter/audio_file_reader.py
@@ -108,7 +108,7 @@ class AudioFileReader:
 
                 X = wave_read.readframes(wave_read.getnframes())
                 sample_type = f"int{target.sample_width * 8}"
-                target.Y = numpy.fromstring(X, dtype=sample_type).reshape(nframes, target.channels)
+                target.Y = numpy.frombuffer(X, dtype=sample_type).reshape(nframes, target.channels)
 
             if sample_type == 'int16':
                 convert_16_bit = numpy.float32(2 ** 15 + 1)


### PR DESCRIPTION
**Description**

This pull request fixes a  encountered when running dr14meter in Python 3.4.0 and Numpy 2.3.4

<class 'ValueError'>, ValueError('The binary mode of fromstring is removed, use frombuffer instead'), <traceback object at 0x7f61369da140>

Issue caused by deprecated use of `numpy.fromstring` to read audio binary data. Replacing it with `numpy.frombuffer` correctly handles binary audio data and maintains original behavior

**Change summary**

Updated audio_file_reader.py in line 111

`target.Y = numpy.frombuffer(X, dtype=sample_type).reshape(nframes, target.channels)`

Previously used numpy.fromstring

**Tested**

Working with Python 3.24.0 and Numpy 2.3.5
DR measurement runs successfuly and encounters no errors